### PR TITLE
Install Haskell VScode extension for Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -19,3 +19,7 @@ tasks:
       export IHP_BASEURL=`gp url 8000`;
       export IHP_IDE_BASEURL=`gp url 8001`;
       ./start
+
+vscode:
+  extensions:
+    - haskell.haskell


### PR DESCRIPTION
# The Problem/Issue/Bug
It's difficult to work with `.hs` files without syntax highlighting, when using Gitpod to work on projects.

## How this PR Solves The Problem
Adding Haskell VScode extension to `.gitpod.yml`, so users can work better with `.hs` files

## Manual Testing Instructions
Click on this link to test it:
https://gitpod.io/#https://github.com/digitallyinduced/ihp-gitpod-template/pull/1

## Related Issue Link(s)

## Release/Deployment notes
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->
